### PR TITLE
Grammar fix in a4

### DIFF
--- a/a4.ipynb
+++ b/a4.ipynb
@@ -51,7 +51,7 @@
     "  \\tanh(x) &= \\frac{e^x - e^{-x}}{e^x + e^{-x}}\n",
     "\\end{align}\n",
     "\n",
-    "proof the following identities:\n",
+    "prove the following identities:\n",
     "\\begin{align}\n",
     "  \\tanh(x) &= 2 \\sigma(2x) - 1 \\\\\n",
     "  \\frac{\\partial}{\\partial x}\\sigma(x) &= \\sigma(x) \\cdot (1-\\sigma(x)) \\\\\n",


### PR DESCRIPTION
In this context, "proof" is a noun, with the corresponding verb being spelled as "prove".